### PR TITLE
Utilize Java Enums for different types

### DIFF
--- a/src/main/java/task/ActionTask.java
+++ b/src/main/java/task/ActionTask.java
@@ -26,7 +26,8 @@ public class ActionTask implements ParseExecutionable {
      * Represents the commands that user can input, and a UNRECOGNIZED as well.
      *
      * This allows the application to handle various commands, and any addition
-     * will be caught here as well.
+     * will be caught here as well. This ensures type safety in handling these
+     * various actions.
      */
     public static enum ActionType {
         LIST, DELETE, MARK, UNMARK, BYE, UNRECOGNIZED, FIND


### PR DESCRIPTION
The ActionTask uses strings to represent different types of actions. 
This only allows it to handle a fixed set of variables.

This could lead to errors and makes the code hard
to implement, as developers have to read and match 
the words for the corresponding actions.

Let's change the String list into an Enum, and use it to indicate 
the respective action type of ActionTask.

This will allow only defined types to be created,
enforcing proper type security and ensuring that
it is easy to define and debug.

I referred to this to learn more:
https://www.w3schools.com/java/java_enums.asp